### PR TITLE
Dropzone improvements

### DIFF
--- a/app/styles/_file-upload.scss
+++ b/app/styles/_file-upload.scss
@@ -1,5 +1,8 @@
 // Based on the file-upload component in Loket
 // Src: https://github.com/lblod/frontend-loket/blob/dcde7a430bb11265e43781e34a192424989bd148/app/styles/_shame.scss#L210
+
+$au-c-upload-dropzone-height: $au-unit * 6;
+
 .au-c-upload {
   border: 2px dashed $au-gray-300;
   background-color: $au-white;
@@ -28,15 +31,16 @@
   align-items: center;
   justify-content: center;
   background-color: $au-gray-100;
-  padding: $au-unit + $au-unit-tiny/4 $au-unit-small;
+  height: $au-c-upload-dropzone-height;
 }
 
 .au-c-upload-label {
   display: flex;
   flex-direction: column;
-  padding: $au-unit-large;
+  justify-content: center;
   text-align: center;
   transition: background-color $au-transition;
+  height: $au-c-upload-dropzone-height;
 
   &,
   &:hover,

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -37,13 +37,8 @@
           >
             {{#if dropzone.active}}
               <label class="au-c-upload-message">
-                {{#if dropzone.valid}}
-                  <AuIcon @icon="check" @alignment="left" />
-                  <small class="au-c-small-text">Drop your file here</small>
-                {{else}}
-                  <AuIcon @icon="triangle" @alignment="left" />
-                  <small class="au-c-small-text">This file type isn't supported</small>
-                {{/if}}
+                <AuIcon @icon="check" @alignment="left" />
+                <small class="au-c-small-text">Drop your file here</small>
               </label>
             {{else}}
               <FileUpload


### PR DESCRIPTION
- Remove the validation since it doesn't work in chrome and always displayed the "invalid file" message
- make the hover message equal in height so the UI doesn't move up and down.